### PR TITLE
Connect to closer peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@
 ## Testing
 ### Docker
 ```sh
-BUILD_MODE=debug docker compose -f docker/docker-compose.yml up --force-recreate
-BUILD_MODE=release docker compose -f docker/docker-compose.yml up --force-recreate
+BUILD_MODE=debug docker compose -f docker/docker-compose.yml up --force-recreate --build
+BUILD_MODE=release docker compose -f docker/docker-compose.yml up --force-recreate --build
 ```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,9 +36,6 @@ services:
       dockerfile: docker/Dockerfile
     image: snowflake:latest
     hostname: peer1
-    ports:
-      - "3001:3001"
-      - "4001:4001"
     network_mode: host
     volumes:
       - snowflake:/shared
@@ -52,9 +49,6 @@ services:
       dockerfile: docker/Dockerfile
     image: snowflake:latest
     hostname: peer2
-    ports:
-      - "3002:3002"
-      - "4002:4002"
     network_mode: host
     volumes:
       - snowflake:/shared
@@ -68,9 +62,6 @@ services:
       dockerfile: docker/Dockerfile
     image: snowflake:latest
     hostname: peer3
-    ports:
-      - "3003:3003"
-      - "4003:4003"
     network_mode: host
     volumes:
       - snowflake:/shared

--- a/node/src/bin.rs
+++ b/node/src/bin.rs
@@ -1,4 +1,3 @@
-use crate::net::Network;
 use crate::node::Node;
 use crate::server::{config, Server};
 use cli::Args;
@@ -52,10 +51,9 @@ async fn main() -> Result<(), NodeError> {
     log::debug!("args: {:?}", args);
 
     let network_config = args.network_config();
-    let network = Network::new(network_config).unwrap();
 
     let node = Arc::new(Node::new(
-        network,
+        network_config,
         args.max_out_connections,
         args.max_latency_records,
         args.sync_headers,

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -97,6 +97,9 @@ pub struct Args {
     #[arg(long, default_value = "50")]
     pub max_peers: Option<usize>,
 
+    #[arg(long, default_value = "50")]
+    pub max_light_peers: Option<usize>,
+
     /// RPC port
     #[arg(long, default_value_t = 9781)]
     pub rpc_port: u16,
@@ -170,6 +173,7 @@ impl Args {
             bucket_size: 500_000,           // 500 kB
             max_concurrent_handshakes: self.max_handshakes,
             max_peers: self.max_peers,
+            max_light_peers: self.max_light_peers,
             bootstrappers: Bootstrappers::new(
                 &self.bootstrappers_path,
                 &self.light_bootstrappers_path,

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -88,6 +88,10 @@ pub struct Args {
     #[arg(long, default_value_t = 60000)]
     pub intervals_get_peer_list_ms: u64,
 
+    /// Intervals configuration
+    #[arg(long, default_value_t = 60000)]
+    pub intervals_find_nodes: u64,
+
     #[arg(long, default_value_t = 9000)]
     pub metrics_port: u16,
 
@@ -132,6 +136,7 @@ impl Args {
         Intervals {
             ping: self.intervals_ping_ms,
             get_peer_list: self.intervals_get_peer_list_ms,
+            find_nodes: self.intervals_find_nodes,
         }
     }
 

--- a/node/src/dht/kademlia.rs
+++ b/node/src/dht/kademlia.rs
@@ -76,7 +76,7 @@ impl KademliaDht {
     /// Find up to `n` unique nodes that are the closest to the `bucket`.
     fn find_closest_nodes(
         &self,
-        nodes: RwLockReadGuard<HashMap<NodeId, DhtBuckets>>,
+        nodes: RwLockReadGuard<IndexMap<NodeId, DhtBuckets>>,
         bucket: &Bucket,
         excluding: &[NodeId],
         mut n: usize,

--- a/node/src/dht/kademlia.rs
+++ b/node/src/dht/kademlia.rs
@@ -67,7 +67,7 @@ impl KademliaDht {
         }
     }
 
-    fn distance(a: &Bucket, b: Bucket) -> Bucket {
+    pub fn distance(a: &Bucket, b: Bucket) -> Bucket {
         a ^ b
     }
 

--- a/node/src/dht/mod.rs
+++ b/node/src/dht/mod.rs
@@ -3,6 +3,7 @@ pub mod kademlia;
 
 use crate::dht::kademlia::{LockedMapDb, ValueOrNodes};
 use crate::id::NodeId;
+use crate::net::queue::ConnectionData;
 use jsonrpsee::types::ErrorObject;
 use ruint::Uint;
 use serde::Deserialize;
@@ -100,7 +101,7 @@ pub enum LightMessage {
     Store(DhtId, Vec<u8>),
     FindNode(Bucket),
     FindValue(DhtId, Bucket),
-    Nodes(Vec<NodeId>),
+    Nodes(Vec<ConnectionData>),
 }
 
 #[derive(Debug)]

--- a/node/src/id/node.rs
+++ b/node/src/id/node.rs
@@ -51,7 +51,7 @@ impl<'a> From<&'a Vec<NodeId>> for VecNodeIds<'a> {
 }
 
 impl Display for VecNodeIds<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "[")?;
         let mut first = true;
         for node_id in self.0 {

--- a/node/src/net/light.rs
+++ b/node/src/net/light.rs
@@ -14,7 +14,7 @@ use crate::utils::unpacker::StatelessBlock;
 use crate::Arc;
 use flume::Sender;
 use indexmap::IndexMap;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use tokio::sync::broadcast;
 use tokio::sync::oneshot;
 
@@ -103,8 +103,10 @@ impl LightNetwork {
                 };
                 Some(res)
             }
-            LightMessage::Nodes(_node_ids) => {
+            LightMessage::Nodes(node_ids) => {
                 todo!(); // TODO: store node_ids which are interesting to us.
+                // TODO: look at potentially_add_nodes function in LightPeers.
+                None
             }
         };
 
@@ -115,6 +117,8 @@ impl LightNetwork {
             (None, None) => (),
             _ => {
                 log::error!("unexpected state for res and resp values");
+                log::error!("this is a logic bug. please report it.");
+                // unreachable!();
             }
         }
     }
@@ -221,5 +225,196 @@ impl DhtContent<u64, StatelessBlock> for DhtBlocks {
 
     fn decode(bytes: &[u8]) -> Result<StatelessBlock, LightError> {
         StatelessBlock::unpack(bytes).map_err(|_| light_errors::DECODING_FAILED)
+    }
+}
+
+pub struct LightPeers {
+    node_id: NodeId,
+    light_peers: Arc<RwLock<HashMap<NodeId, DhtBuckets>>>,
+}
+
+impl LightPeers {
+    pub fn new(node_id: NodeId, light_peers: Arc<RwLock<HashMap<NodeId, DhtBuckets>>>) -> Self {
+        Self {
+            node_id,
+            light_peers,
+        }
+    }
+
+    /// Find a maximum of `n` light peers which are the closest to the `bucket`.
+    pub fn closest(&self, bucket: &Bucket, n: usize) -> Vec<NodeId> {
+        // TODO this function could be cached if bucket is the same and n is <=.
+        let light_peers = self.light_peers.read().unwrap();
+        // TODO provide From / Into impl for NodeId to Bucket and implement distance function over
+        //  Into<Bucket> generics.
+        let distances: BTreeMap<_, _> = light_peers
+            .keys()
+            .map(|node_id| {
+                let distance =
+                    KademliaDht::distance(bucket, Bucket::from_be_bytes((*node_id).into()));
+                (*node_id, distance)
+            })
+            .collect();
+        drop(light_peers);
+        distances
+            .into_iter()
+            .take(n)
+            .map(|(node_id, _)| node_id)
+            .collect()
+    }
+
+    pub fn check_interesting_node_ids(&self, node_ids: &[NodeId]) -> Vec<NodeId> {
+        let my_bucket = Bucket::from_be_bytes(self.node_id.into());
+        let distances_from_us: Vec<_> = node_ids
+            .iter()
+            .map(|node_id| {
+                let bucket_b = Bucket::from_be_bytes((*node_id).into());
+                KademliaDht::distance(&my_bucket, bucket_b)
+            })
+            .collect();
+        let mut distances_rev = {
+            let mut distances_from_us_clone: Vec<_> =
+                distances_from_us.clone().into_iter().enumerate().collect();
+            distances_from_us_clone.sort_by_key(|(_, distance)| *distance);
+            distances_from_us_clone
+                .into_iter()
+                .rev()
+                .collect::<Vec<_>>()
+        };
+        let mut closest_indexes = Vec::new();
+        {
+            let light_peers = self.light_peers.read().unwrap();
+            for light_peer in light_peers.keys() {
+                if closest_indexes.len() >= node_ids.len() {
+                    break;
+                }
+                let i = {
+                    let mut i = 0;
+                    loop {
+                        if i >= distances_rev.len() {
+                            break None;
+                        }
+                        let (idx, distance) = distances_rev.get(i).unwrap();
+                        let light_peer_bucket = Bucket::from_be_bytes((*light_peer).into());
+                        let distance_with_peer = KademliaDht::distance(&my_bucket, light_peer_bucket);
+                        if distance < &distance_with_peer {
+                            let idx = *idx;
+                            distances_rev.remove(i);
+                            break Some(idx);
+                        }
+                        i += 1;
+                    }
+                };
+                if let Some(i) = i {
+                    closest_indexes.push(i);
+                }
+            }
+        }
+        closest_indexes
+            .into_iter()
+            .map(|index| node_ids[index])
+            .collect()
+    }
+
+    pub fn potentially_add_nodes(&self, node_ids: &[NodeId]) {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_check_interesting_node_ids() {
+        // Create a base node ID (our node)
+        let our_node_id = NodeId::from([0u8; 20]);
+
+        // Create some peer nodes that are at varying distances
+        let far_peer = NodeId::from([0xF0; 20]);  // Very far peer
+        let medium_peer = NodeId::from([0x80; 20]); // Medium distance peer
+        
+        // Create the light peers map
+        let light_peers = Arc::new(RwLock::new(HashMap::from([
+            (far_peer, DhtBuckets { block: Default::default() }),
+            (medium_peer, DhtBuckets { block: Default::default() }),
+        ])));
+
+        let light_peers_struct = LightPeers::new(our_node_id, light_peers);
+
+        // Test case 1: Node closer than all peers
+        let close_node = NodeId::from([0x10; 20]); // Very close to our node
+        let result = light_peers_struct.check_interesting_node_ids(&[close_node]);
+        assert_eq!(result, vec![close_node], "Should return the closer node");
+
+        // Test case 2: Multiple nodes, some closer some farther
+        let very_close_node = NodeId::from([0x05; 20]);
+        let very_far_node = NodeId::from([0xFF; 20]);
+        let nodes_to_check = vec![very_far_node, very_close_node];
+        let result = light_peers_struct.check_interesting_node_ids(&nodes_to_check);
+        assert_eq!(result, vec![very_close_node], "Should only return the closer node");
+
+        // Test case 3: All nodes farther than peers
+        let far_node_1 = NodeId::from([0xFF; 20]);
+        let far_node_2 = NodeId::from([0xFE; 20]);
+        let result = light_peers_struct.check_interesting_node_ids(&[far_node_1, far_node_2]);
+        assert!(result.is_empty(), "Should return empty vec when no nodes are closer than peers");
+
+        // Test case 4: Empty input
+        let result = light_peers_struct.check_interesting_node_ids(&[]);
+        assert!(result.is_empty(), "Should handle empty input gracefully");
+
+        // Test case 5: Multiple interesting nodes
+        let close_node_1 = NodeId::from([0x01; 20]);
+        let close_node_2 = NodeId::from([0x02; 20]);
+        let nodes_to_check = vec![close_node_1, close_node_2];
+        let result = light_peers_struct.check_interesting_node_ids(&nodes_to_check);
+        assert_eq!(result.len(), 2, "Should return both close nodes");
+        assert!(result.contains(&close_node_1));
+        assert!(result.contains(&close_node_2));
+    }
+
+    #[test]
+    fn test_closest() {
+        // Create a base node ID (our node)
+        let our_node_id = NodeId::from([0u8; 20]);
+
+        // Create peers at different distances
+        let very_close_peer = NodeId::from([0x01; 20]);
+        let close_peer = NodeId::from([0x10; 20]);
+        let medium_peer = NodeId::from([0x80; 20]);
+        let far_peer = NodeId::from([0xFF; 20]);
+        
+        // Create the light peers map
+        let light_peers = Arc::new(RwLock::new(HashMap::from([
+            (very_close_peer, DhtBuckets { block: Default::default() }),
+            (close_peer, DhtBuckets { block: Default::default() }),
+            (medium_peer, DhtBuckets { block: Default::default() }),
+            (far_peer, DhtBuckets { block: Default::default() }),
+        ])));
+        
+        // Create the LightPeers struct
+        let light_peers_struct = LightPeers::new(our_node_id, light_peers.clone());
+
+        // Create a target bucket
+        let target_bucket = Bucket::from_be_bytes([0u8; 20]);
+
+        // Test case 1: Get single closest peer
+        let result = light_peers_struct.closest(&target_bucket, 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], very_close_peer);
+
+        // Test case 2: Get two closest peers
+        let result = light_peers_struct.closest(&target_bucket, 2);
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&very_close_peer));
+        assert!(result.contains(&close_peer));
+        assert!(!result.contains(&medium_peer));
+        assert!(!result.contains(&far_peer));
+
+        // Test case 3: Request more peers than available
+        let result = light_peers_struct.closest(&target_bucket, 10);
+        assert_eq!(result.len(), 4); // Should return all
     }
 }

--- a/node/src/net/light.rs
+++ b/node/src/net/light.rs
@@ -15,44 +15,43 @@ use crate::utils::unpacker::StatelessBlock;
 use crate::Arc;
 use flume::Sender;
 use indexmap::IndexMap;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::{LockResult, RwLockReadGuard, RwLockWriteGuard};
 use tokio::sync::broadcast;
 use tokio::sync::oneshot;
+
+#[derive(Debug)]
+pub struct LightNetworkConfig {
+    pub sync_headers: bool,
+    pub max_lookups: usize,
+    pub alpha: usize,
+}
 
 #[derive(Debug)]
 pub struct LightNetwork {
     pub kademlia_dht: KademliaDht,
     pub block_dht: Arc<DhtBlocks>,
     pub light_peers: LightPeers,
-    sync_headers: bool,
-    max_lookups: usize,
-    alpha: usize,
+    config: LightNetworkConfig,
 }
 
 impl LightNetwork {
     pub fn new(
         node_id: NodeId,
+        light_peers: LightPeers,
         peer_infos: Arc<RwLock<IndexMap<NodeId, PeerInfo>>>,
         mail_tx: Sender<Mail>,
-        connection_queue: Arc<ConnectionQueue>,
         chain_id: ChainId,
-        sync_headers: bool,
-        max_lookups: usize,
-        alpha: usize,
+        config: LightNetworkConfig,
     ) -> Self {
         let store = RwLock::new(HashMap::new());
         let block_dht = Arc::new(DhtBlocks::new(node_id, Bucket::from(10), store));
-        let light_peers = Arc::new(RwLock::new(Default::default()));
         let kademlia_dht = KademliaDht::new(peer_infos, light_peers.clone(), mail_tx, chain_id, 10);
-        let light_peers = LightPeers::new(node_id, light_peers.clone(), connection_queue);
         Self {
             kademlia_dht,
             block_dht,
             light_peers,
-            sync_headers,
-            max_lookups,
-            alpha,
+            config,
         }
     }
 
@@ -61,7 +60,7 @@ impl LightNetwork {
         node: Arc<Node>,
         mut rx: broadcast::Receiver<()>,
     ) -> Result<(), NodeError> {
-        if self.sync_headers {
+        if self.config.sync_headers {
             let block_dht = self.block_dht.clone();
             let rx = rx.resubscribe();
             tokio::spawn(async move {
@@ -158,7 +157,12 @@ impl LightNetwork {
             None => {
                 let value = self
                     .kademlia_dht
-                    .search_value(&DHT::id(), &bucket, self.max_lookups, self.alpha)
+                    .search_value(
+                        &DHT::id(),
+                        &bucket,
+                        self.config.max_lookups,
+                        self.config.alpha,
+                    )
                     .await?;
                 DHT::decode(&value)
             }
@@ -231,7 +235,7 @@ impl DhtContent<u64, StatelessBlock> for DhtBlocks {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LightPeers {
     node_id: NodeId,
     pub light_peers: Arc<RwLock<HashMap<NodeId, DhtBuckets>>>,
@@ -239,14 +243,10 @@ pub struct LightPeers {
 }
 
 impl LightPeers {
-    pub fn new(
-        node_id: NodeId,
-        light_peers: Arc<RwLock<HashMap<NodeId, DhtBuckets>>>,
-        connection_queue: Arc<ConnectionQueue>,
-    ) -> Self {
+    pub fn new(node_id: NodeId, connection_queue: Arc<ConnectionQueue>) -> Self {
         Self {
             node_id,
-            light_peers,
+            light_peers: Default::default(),
             connection_queue,
         }
     }
@@ -259,29 +259,7 @@ impl LightPeers {
         self.light_peers.write()
     }
 
-    /// Find a maximum of `n` light peers which are the closest to the `bucket`.
-    pub fn closest(&self, bucket: &Bucket, n: usize) -> Vec<NodeId> {
-        // TODO this function could be cached if bucket is the same and n is <=.
-        let light_peers = self.light_peers.read().unwrap();
-        // TODO provide From / Into impl for NodeId to Bucket and implement distance function over
-        //  Into<Bucket> generics.
-        let distances: BTreeMap<_, _> = light_peers
-            .keys()
-            .map(|node_id| {
-                let distance =
-                    KademliaDht::distance(bucket, Bucket::from_be_bytes((*node_id).into()));
-                (*node_id, distance)
-            })
-            .collect();
-        drop(light_peers);
-        distances
-            .into_iter()
-            .take(n)
-            .map(|(node_id, _)| node_id)
-            .collect()
-    }
-
-    fn check_interesting_node_ids(&self, node_ids: &Vec<NodeId>) -> Vec<NodeId> {
+    fn check_interesting_node_ids(&self, node_ids: Vec<NodeId>) -> Vec<NodeId> {
         let my_bucket = Bucket::from_be_bytes(self.node_id.into());
         let distances_from_us: Vec<_> = node_ids
             .iter()
@@ -339,7 +317,7 @@ impl LightPeers {
     /// If so, add them.
     pub fn potentially_add_nodes(&self, nodes: Vec<ConnectionData>) {
         let node_ids = self.check_interesting_node_ids(
-            &nodes
+            nodes
                 .iter()
                 .map(|ConnectionData { node_id, .. }| *node_id)
                 .collect(),
@@ -367,11 +345,11 @@ mod tests {
         let our_node_id = NodeId::from([0u8; 20]);
 
         // Create some peer nodes that are at varying distances
-        let far_peer = NodeId::from([0xF0; 20]); // Very far peer
-        let medium_peer = NodeId::from([0x80; 20]); // Medium distance peer
+        let far_peer = NodeId::from([0xF0; 20]);
+        let medium_peer = NodeId::from([0x80; 20]);
 
-        // Create the light peers map
-        let light_peers = Arc::new(RwLock::new(HashMap::from([
+        let light_peers = LightPeers::new(our_node_id, Arc::new(ConnectionQueue::new(0)));
+        light_peers.write().unwrap().extend(HashMap::from([
             (
                 far_peer,
                 DhtBuckets {
@@ -384,21 +362,18 @@ mod tests {
                     block: Default::default(),
                 },
             ),
-        ])));
-
-        let light_peers_struct =
-            LightPeers::new(our_node_id, light_peers, Arc::new(ConnectionQueue::new(0)));
+        ]));
 
         // Test case 1: Node closer than all peers
         let close_node = NodeId::from([0x10; 20]); // Very close to our node
-        let result = light_peers_struct.check_interesting_node_ids(&vec![close_node]);
+        let result = light_peers.check_interesting_node_ids(vec![close_node]);
         assert_eq!(result, vec![close_node], "Should return the closer node");
 
         // Test case 2: Multiple nodes, some closer some farther
         let very_close_node = NodeId::from([0x05; 20]);
         let very_far_node = NodeId::from([0xFF; 20]);
         let nodes_to_check = vec![very_far_node, very_close_node];
-        let result = light_peers_struct.check_interesting_node_ids(&nodes_to_check);
+        let result = light_peers.check_interesting_node_ids(nodes_to_check);
         assert_eq!(
             result,
             vec![very_close_node],
@@ -408,90 +383,23 @@ mod tests {
         // Test case 3: All nodes farther than peers
         let far_node_1 = NodeId::from([0xFF; 20]);
         let far_node_2 = NodeId::from([0xFE; 20]);
-        let result = light_peers_struct.check_interesting_node_ids(&vec![far_node_1, far_node_2]);
+        let result = light_peers.check_interesting_node_ids(vec![far_node_1, far_node_2]);
         assert!(
             result.is_empty(),
             "Should return empty vec when no nodes are closer than peers"
         );
 
         // Test case 4: Empty input
-        let result = light_peers_struct.check_interesting_node_ids(&vec![]);
+        let result = light_peers.check_interesting_node_ids(vec![]);
         assert!(result.is_empty(), "Should handle empty input gracefully");
 
         // Test case 5: Multiple interesting nodes
         let close_node_1 = NodeId::from([0x01; 20]);
         let close_node_2 = NodeId::from([0x02; 20]);
         let nodes_to_check = vec![close_node_1, close_node_2];
-        let result = light_peers_struct.check_interesting_node_ids(&nodes_to_check);
+        let result = light_peers.check_interesting_node_ids(nodes_to_check);
         assert_eq!(result.len(), 2, "Should return both close nodes");
         assert!(result.contains(&close_node_1));
         assert!(result.contains(&close_node_2));
-    }
-
-    #[test]
-    fn test_closest() {
-        // Create a base node ID (our node)
-        let our_node_id = NodeId::from([0u8; 20]);
-
-        // Create peers at different distances
-        let very_close_peer = NodeId::from([0x01; 20]);
-        let close_peer = NodeId::from([0x10; 20]);
-        let medium_peer = NodeId::from([0x80; 20]);
-        let far_peer = NodeId::from([0xFF; 20]);
-
-        // Create the light peers map
-        let light_peers = Arc::new(RwLock::new(HashMap::from([
-            (
-                very_close_peer,
-                DhtBuckets {
-                    block: Default::default(),
-                },
-            ),
-            (
-                close_peer,
-                DhtBuckets {
-                    block: Default::default(),
-                },
-            ),
-            (
-                medium_peer,
-                DhtBuckets {
-                    block: Default::default(),
-                },
-            ),
-            (
-                far_peer,
-                DhtBuckets {
-                    block: Default::default(),
-                },
-            ),
-        ])));
-
-        // Create the LightPeers struct
-        let light_peers_struct = LightPeers::new(
-            our_node_id,
-            light_peers.clone(),
-            Arc::new(ConnectionQueue::new(0)),
-        );
-
-        // Create a target bucket
-        let target_bucket = Bucket::from_be_bytes([0u8; 20]);
-
-        // Test case 1: Get single closest peer
-        let result = light_peers_struct.closest(&target_bucket, 1);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0], very_close_peer);
-
-        // Test case 2: Get two closest peers
-        let result = light_peers_struct.closest(&target_bucket, 2);
-        assert_eq!(result.len(), 2);
-        assert!(result.contains(&very_close_peer));
-        assert!(result.contains(&close_peer));
-        assert!(!result.contains(&medium_peer));
-        assert!(!result.contains(&far_peer));
-
-        // Test case 3: Request more peers than available
-        let result = light_peers_struct.closest(&target_bucket, 10);
-        assert_eq!(result.len(), 4); // Should return all
     }
 }

--- a/node/src/net/mod.rs
+++ b/node/src/net/mod.rs
@@ -4,7 +4,6 @@ use crate::dht::{Bucket, DhtId, LightMessage, LightResult};
 use crate::dht::{DhtBuckets, LightValue};
 use crate::id::{ChainId, NodeId};
 use crate::message::{mail_box::MailBox, pipeline::Pipeline, MiniMessage, SubscribableMessage};
-use crate::net::light::LightPeers;
 use crate::net::sdk::{FindNode, FindValue, LightHandshake};
 use crate::net::{
     ip::SignedIp,
@@ -79,7 +78,6 @@ pub struct Network {
     pub client_config: Arc<ClientConfig>,
     /// All peers discovered by the node
     pub peers_infos: Arc<RwLock<IndexMap<NodeId, PeerInfo>>>, // TODO can we find a way to do it lock-less ?
-    pub light_peers: LightPeers,
     pub bootstrappers: RwLock<HashMap<NodeId, Option<DhtBuckets>>>,
     pub out_pipeline: Arc<Pipeline>,
     /// The canonically sorted validators map
@@ -213,7 +211,7 @@ impl Peer {
         &self.channels.rpl
     }
 
-    pub fn take_tls(
+    fn take_tls(
         &mut self,
     ) -> (
         ReadHalf<TlsStream<TcpStream>>,

--- a/node/src/net/mod.rs
+++ b/node/src/net/mod.rs
@@ -93,6 +93,7 @@ pub struct Network {
 pub struct Intervals {
     pub ping: u64,
     pub get_peer_list: u64,
+    pub find_nodes: u64,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -568,7 +569,7 @@ impl Peer {
                 }
             }
             Message::Pong(_pong) => {}
-            _ => log::debug!("unsupported message {} {}", mini, self.identity.node_id),
+            _ => log::trace!("unsupported message {} {}", mini, self.identity.node_id),
         };
 
         Ok(())
@@ -581,7 +582,7 @@ impl Peer {
         sender: &PeerSender,
         light_message: sdk::light_request::Message,
     ) -> Result<(), NodeError> {
-        log::debug!("received light message {light_message:?}");
+        log::trace!("received light message {light_message:?}");
         let chain_id = c_chain_id.as_ref().to_vec();
         let res = match light_message {
             sdk::light_request::Message::LightHandshake(LightHandshake { buckets }) => {
@@ -664,7 +665,7 @@ impl Peer {
         light_request: sdk::light_request::Message,
         light_response: sdk::light_response::Message,
     ) -> Result<(), NodeError> {
-        log::debug!("received light response {light_response:?}");
+        log::trace!("received light response {light_response:?}");
 
         match light_response {
             sdk::light_response::Message::Ack(_) => {}

--- a/node/src/net/mod.rs
+++ b/node/src/net/mod.rs
@@ -4,6 +4,7 @@ use crate::dht::{Bucket, DhtId, LightMessage, LightResult};
 use crate::dht::{DhtBuckets, LightValue};
 use crate::id::{ChainId, NodeId};
 use crate::message::{mail_box::MailBox, pipeline::Pipeline, MiniMessage, SubscribableMessage};
+use crate::net::light::LightPeers;
 use crate::net::sdk::{FindNode, FindValue, LightHandshake};
 use crate::net::{
     ip::SignedIp,
@@ -78,7 +79,7 @@ pub struct Network {
     pub client_config: Arc<ClientConfig>,
     /// All peers discovered by the node
     pub peers_infos: Arc<RwLock<IndexMap<NodeId, PeerInfo>>>, // TODO can we find a way to do it lock-less ?
-    pub light_peers: Arc<RwLock<HashMap<NodeId, DhtBuckets>>>,
+    pub light_peers: LightPeers,
     pub bootstrappers: RwLock<HashMap<NodeId, Option<DhtBuckets>>>,
     pub out_pipeline: Arc<Pipeline>,
     /// The canonically sorted validators map

--- a/node/src/net/node.rs
+++ b/node/src/net/node.rs
@@ -363,7 +363,7 @@ impl Network {
 
     pub fn remove_peers(
         peers_infos: Arc<RwLock<IndexMap<NodeId, PeerInfo>>>,
-        light_peers: &mut RwLockWriteGuard<HashMap<NodeId, DhtBuckets>>,
+        light_peers: &mut RwLockWriteGuard<IndexMap<NodeId, DhtBuckets>>,
         node_ids_errs: Vec<(&NodeId, Option<&NodeError>)>,
     ) {
         for (node_id, err) in &node_ids_errs {
@@ -390,14 +390,14 @@ impl Network {
 
         {
             for (node_id, _) in &node_ids_errs {
-                light_peers.remove(node_id);
+                light_peers.swap_remove(*node_id);
             }
         }
     }
 
     pub fn disconnect_peer(
         peers_infos: Arc<RwLock<IndexMap<NodeId, PeerInfo>>>,
-        light_peers: &mut RwLockWriteGuard<HashMap<NodeId, DhtBuckets>>,
+        light_peers: &mut RwLockWriteGuard<IndexMap<NodeId, DhtBuckets>>,
         node_id: &NodeId,
         err: Option<&NodeError>,
     ) {

--- a/node/src/net/queue.rs
+++ b/node/src/net/queue.rs
@@ -1,12 +1,15 @@
 use crate::id::NodeId;
 use crate::node::Node;
+use crate::utils::ip::{ip_from_octets, ip_octets};
 use flume::{Receiver, Sender};
+use proto_lib::p2p::ClaimedIpPort;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tokio::sync::{broadcast, Semaphore};
 
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct ConnectionData {
     pub node_id: NodeId,
     pub socket_addr: SocketAddr,
@@ -16,9 +19,50 @@ pub struct ConnectionData {
     pub x509_certificate: Vec<u8>,
 }
 
+impl TryFrom<ClaimedIpPort> for ConnectionData {
+    type Error = ();
+
+    fn try_from(value: ClaimedIpPort) -> Result<Self, Self::Error> {
+        // TODO error handling
+        let x509_certificate = value.x509_certificate;
+        let node_id = NodeId::from_cert(x509_certificate.clone());
+        let port = value.ip_port.try_into().map_err(|_| ())?;
+        let ip = ip_from_octets(value.ip_addr).map_err(|_| ())?;
+        let socket_addr = SocketAddr::new(ip, port);
+        let timestamp = value.timestamp;
+
+        Ok(ConnectionData {
+            node_id,
+            socket_addr,
+            timestamp,
+            x509_certificate,
+        })
+    }
+}
+
+impl From<ConnectionData> for ClaimedIpPort {
+    fn from(value: ConnectionData) -> Self {
+        let x509_certificate = value.x509_certificate;
+        let socket_addr = value.socket_addr;
+        let ip_addr = ip_octets(socket_addr.ip());
+        let ip_port = socket_addr.port().into();
+        let timestamp = value.timestamp;
+
+        ClaimedIpPort {
+            x509_certificate,
+            ip_addr,
+            ip_port,
+            timestamp,
+            signature: vec![],
+            tx_id: vec![],
+        }
+    }
+}
+
 /// A connection queue to manage and control concurrent connections
 /// This is to prevent too much concurrent connection and to remember about those which
 /// have been tried so far.
+#[derive(Debug)]
 pub struct ConnectionQueue {
     semaphore: Arc<Semaphore>,
     connections: RwLock<HashMap<NodeId, usize>>,
@@ -102,13 +146,14 @@ impl ConnectionQueue {
         }
     }
 
-    pub fn add_connection(&self, data: ConnectionData) -> bool {
+    pub fn add_connection_without_retries(&self, data: ConnectionData) -> bool {
         let maybe_retries = self.connections.read().unwrap().get(&data.node_id).cloned();
         match maybe_retries {
             None => {
                 self._add_connection(data, 0);
                 true
             }
+            // TODO: maybe remove the retries in the connection queue and still connect.
             Some(_) => false,
         }
     }

--- a/node/src/server/peers.rs
+++ b/node/src/server/peers.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use flume::Sender;
 use proto_lib::p2p::{message::Message, Ping};
-use tokio::sync::oneshot;
+use tokio::sync::{broadcast, oneshot};
 
 // TODO better name
 #[derive(Debug)]
@@ -18,6 +18,7 @@ pub struct PeerInfo {
     pub x509_certificate: Vec<u8>,
     pub sender: PeerSender,
     pub infos: Option<HandshakeInfos>,
+    pub tx: broadcast::Sender<()>,
 }
 
 impl PeerInfo {

--- a/node/src/server/rpc.rs
+++ b/node/src/server/rpc.rs
@@ -707,6 +707,7 @@ mod tests {
             intervals: Intervals {
                 ping: 0,
                 get_peer_list: 0,
+                find_nodes: 0,
             },
             back_off: BackoffParams {
                 initial_duration: Default::default(),

--- a/node/src/server/rpc.rs
+++ b/node/src/server/rpc.rs
@@ -672,7 +672,6 @@ mod tests {
     use crate::net::node::NetworkConfig;
     use crate::net::BackoffParams;
     use crate::net::Intervals;
-    use crate::net::Network;
     use crate::node::Node;
     use alloy::providers::{network::EthereumWallet, Provider, ProviderBuilder};
     use alloy::signers::local::PrivateKeySigner;
@@ -697,7 +696,7 @@ mod tests {
         });
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         log::debug!("start");
-        let network = Network::new(NetworkConfig {
+        let config = NetworkConfig {
             socket_addr: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0)),
             network_id: 0,
             eth_network_id: 0,
@@ -723,9 +722,8 @@ mod tests {
             dht_buckets: DhtBuckets {
                 block: Default::default(),
             },
-        })
-        .unwrap();
-        let node = Node::new(network, 1, 1, false);
+        };
+        let node = Node::new(config, 1, 1, false);
 
         let rpc = Rpc::new(Arc::from(node), 0, tx).await.unwrap();
         let addr = rpc.local_addr();

--- a/node/src/server/rpc.rs
+++ b/node/src/server/rpc.rs
@@ -718,6 +718,7 @@ mod tests {
             bucket_size: 0,
             max_concurrent_handshakes: 0,
             max_peers: None,
+            max_light_peers: None,
             bootstrappers: HashMap::new(),
             dht_buckets: DhtBuckets {
                 block: Default::default(),

--- a/node/src/utils/rlp.rs
+++ b/node/src/utils/rlp.rs
@@ -1071,7 +1071,6 @@ impl AccessList {
         } else {
             let length = Rlp::decode_list(bytes, &mut cursor)?;
             let start_cursor = cursor;
-            dbg!(&bytes[cursor..]);
             let mut access_list = Vec::new();
             while cursor < start_cursor + length as usize {
                 let address = Rlp::decode_fixed_bytes(bytes, &mut cursor)?;

--- a/proto/sdk.proto
+++ b/proto/sdk.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+import "p2p.proto";
 
 package sdk;
 
@@ -52,16 +53,12 @@ message FindNode {
 message LightResponse {
   oneof message {
     Ack ack = 1;
-    Nodes nodes = 2;
+    p2p.PeerList nodes = 2;
     Value value = 3;
   }
 }
 
 message Ack {}
-
-message Nodes {
-  repeated bytes node_ids = 1;
-}
 
 message Value {
   bytes value = 1;

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -20,8 +20,8 @@ impl From<sdk::Value> for sdk::light_response::Message {
     }
 }
 
-impl From<sdk::Nodes> for sdk::light_response::Message {
-    fn from(message: sdk::Nodes) -> Self {
+impl From<p2p::PeerList> for sdk::light_response::Message {
+    fn from(message: p2p::PeerList) -> Self {
         Self::Nodes(message)
     }
 }

--- a/proto/src/sdk.rs
+++ b/proto/src/sdk.rs
@@ -73,18 +73,13 @@ pub mod light_response {
         #[prost(message, tag = "1")]
         Ack(super::Ack),
         #[prost(message, tag = "2")]
-        Nodes(super::Nodes),
+        Nodes(super::super::p2p::PeerList),
         #[prost(message, tag = "3")]
         Value(super::Value),
     }
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Ack {}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Nodes {
-    #[prost(bytes = "vec", repeated, tag = "1")]
-    pub node_ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
-}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Value {
     #[prost(bytes = "vec", tag = "1")]


### PR DESCRIPTION
Currently, we don't do anything when receiving a `Nodes` message.
In this PR, we check if any of the nodes that are proposed are interesting to us.
The rule is very easy for now, we just add nodes if we haven't reached the maximum amount of peers, and choose nodes that are closer than what we have in store to replace them.
We will have more complex rules with https://github.com/iFrostizz/snowflake/issues/31
Also, now the inner message of `Nodes` is a `p2p::PeerList`.